### PR TITLE
Ignore parts assigned to builds as long as still in storage

### DIFF
--- a/lib/warehouse/components.ex
+++ b/lib/warehouse/components.ex
@@ -12,7 +12,7 @@ defmodule Warehouse.Components do
         join: p in assoc(s, :parts),
         join: l in assoc(p, :location),
         where: c.component_id == ^component_id,
-        where: is_nil(p.assembly_build_id),
+        # where: is_nil(p.assembly_build_id),
         where: is_nil(p.rma_description),
         where: l.area == :storage,
         where: l.id not in ^excluded_picking_locations(),


### PR DESCRIPTION
Because the old legacy system is still in place with part assignment on creation, a lot of the inventory levels here are off. This PR still counts parts if they are assigned to a build, as long as the part is in a storage location. This should give us a more accurate list of what can be picked, and what our available quantity is while testing.